### PR TITLE
Remove `padding_left` setting to ensure all the plots have the same width

### DIFF
--- a/dynamic.py
+++ b/dynamic.py
@@ -41,7 +41,6 @@ class ChannelsView(HasTraits):
                 plot.title = channel
                 if len(plots) >= 1:
                     plot.value_axis.visible = False
-                    plot.padding_left = 1
                 plots.append(plot)
         hpc = HPlotContainer(*plots)
         return hpc

--- a/dynamic.py
+++ b/dynamic.py
@@ -40,10 +40,17 @@ class ChannelsView(HasTraits):
                 plot = Plot(apd)
                 plot.plot((channel, DEPTH), origin='top left')
                 plot.title = channel
+                plot.padding_left = 0
+                plot.padding_right = 0
                 if len(plots) >= 1:
                     plot.value_axis.visible = False
                 plots.append(plot)
-        hpc = HPlotContainer(*plots, spacing=1)
+        hpc = HPlotContainer(
+            *plots,
+            padding_left=50,
+            padding_right=50,
+            spacing=1
+        )
         return hpc
 
 channel_plots_editor = InstanceEditor(


### PR DESCRIPTION
This PR is to fix plot layout problem #2. In my environment, all plots will be displayed at the same width as the screenshot below.

<img width="1112" alt="Screen Shot 2023-04-19 at 11 17 56" src="https://user-images.githubusercontent.com/217541/232952000-2b22fd48-1ae4-49da-93b2-b3a370870eab.png">
