### PR TITLE
Handle missing values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# PyCharm
+.idea/

--- a/dynamic.py
+++ b/dynamic.py
@@ -85,7 +85,7 @@ class DataView(HasStrictTraits):
                 fd.path,
                 names=True,
                 converters={
-                    i: lambda x: float(x) if x != MISSING_VALUE else np.nan
+                    i: lambda x: float(x.strip(b'%')) if x != MISSING_VALUE else np.nan
                     for i in range(column_num)
                 },
             )

--- a/dynamic.py
+++ b/dynamic.py
@@ -85,7 +85,7 @@ class DataView(HasStrictTraits):
                 fd.path,
                 names=True,
                 converters={
-                    i: lambda x: float(x.strip(b'%')) if x != MISSING_VALUE else np.nan
+                    i: lambda x: float(x) if x != MISSING_VALUE else np.nan
                     for i in range(column_num)
                 },
             )

--- a/dynamic.py
+++ b/dynamic.py
@@ -13,7 +13,7 @@ from traitsui.api import (
 )
 
 DEPTH = "DEPTH"
-MISSING_VALUE = -999.25
+MISSING_VALUE = b'-999.2500'
 
 
 class DrillData(HasStrictTraits):
@@ -79,9 +79,16 @@ class DataView(HasStrictTraits):
         status = fd.open()
         if status == OK:
             self.filename = fd.filename
-            data = np.genfromtxt(fd.path, names=True)
-            for name in data.dtype.names:
-                data[name][data[name] == MISSING_VALUE] = np.nan
+            with open(fd.path) as f:
+                column_num = len(f.readline().split())
+            data = np.genfromtxt(
+                fd.path,
+                names=True,
+                converters={
+                    i: lambda x: float(x.strip(b'%')) if x != MISSING_VALUE else np.nan
+                    for i in range(column_num)
+                },
+            )
             self.drill_data = DrillData(data=data)
 
 

--- a/dynamic.py
+++ b/dynamic.py
@@ -13,7 +13,7 @@ from traitsui.api import (
 )
 
 DEPTH = "DEPTH"
-MISSING_VALUE = b'-999.2500'
+MISSING_VALUE = -999.25
 
 
 class DrillData(HasStrictTraits):
@@ -79,16 +79,9 @@ class DataView(HasStrictTraits):
         status = fd.open()
         if status == OK:
             self.filename = fd.filename
-            with open(fd.path) as f:
-                column_num = len(f.readline().split())
-            data = np.genfromtxt(
-                fd.path,
-                names=True,
-                converters={
-                    i: lambda x: float(x.strip(b'%')) if x != MISSING_VALUE else np.nan
-                    for i in range(column_num)
-                },
-            )
+            data = np.genfromtxt(fd.path, names=True)
+            for name in data.dtype.names:
+                data[name][data[name] == MISSING_VALUE] = np.nan
             self.drill_data = DrillData(data=data)
 
 

--- a/dynamic.py
+++ b/dynamic.py
@@ -13,6 +13,7 @@ from traitsui.api import (
 )
 
 DEPTH = "DEPTH"
+MISSING_VALUE = -999.25
 
 
 class DrillData(HasStrictTraits):
@@ -79,6 +80,8 @@ class DataView(HasStrictTraits):
         if status == OK:
             self.filename = fd.filename
             data = np.genfromtxt(fd.path, names=True)
+            for name in data.dtype.names:
+                data[name][data[name] == MISSING_VALUE] = np.nan
             self.drill_data = DrillData(data=data)
 
 


### PR DESCRIPTION
This PR is to fix #1. `numpy.genfromtxt()` has `missing_values` option, but it does not convert float values but only string values. So `data` has to be modified after calling `numpy.genfromtxt()`.